### PR TITLE
Webhook pagination

### DIFF
--- a/actions/integration_actions.jsx
+++ b/actions/integration_actions.jsx
@@ -17,6 +17,20 @@ export function loadIncomingHooksAndProfilesForTeam(teamId, page = 0, perPage = 
     };
 }
 
+export function loadAllIncomingHooksAndProfilesForTeam(teamId) {
+    return async (dispatch) => {
+        let page = 0;
+        let {data} = await dispatch(IntegrationActions.getIncomingHooks(teamId, page, DEFAULT_PAGE_SIZE));
+        let incomingWebhooksList = [];
+        while (data.length > 0) {
+            incomingWebhooksList = incomingWebhooksList.concat(data);
+            data = await dispatch(IntegrationActions.getIncomingHooks(teamId, page, DEFAULT_PAGE_SIZE));
+            ++page;
+        }
+        dispatch(loadProfilesForIncomingHooks(incomingWebhooksList));
+    };
+}
+
 export function loadProfilesForIncomingHooks(hooks) {
     return async (dispatch, getState) => {
         const state = getState();
@@ -43,6 +57,20 @@ export function loadOutgoingHooksAndProfilesForTeam(teamId, page = 0, perPage = 
         if (data) {
             dispatch(loadProfilesForOutgoingHooks(data));
         }
+    };
+}
+
+export function loadAllOutgoingHooksAndProfilesForTeam(teamId) {
+    return async (dispatch) => {
+        let page = 0;
+        let {data} = await dispatch(IntegrationActions.getOutgoingHooks('', teamId, page, DEFAULT_PAGE_SIZE));
+        let outgoingWebhooksList = [];
+        while (data.length > 0) {
+            outgoingWebhooksList = outgoingWebhooksList.concat(data);
+            data = await dispatch(IntegrationActions.getOutgoingHooks('', teamId, page, DEFAULT_PAGE_SIZE));
+            ++page;
+        }
+        dispatch(loadProfilesForOutgoingHooks(outgoingWebhooksList));
     };
 }
 

--- a/components/backstage/components/backstage_list.jsx
+++ b/components/backstage/components/backstage_list.jsx
@@ -3,11 +3,17 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import * as Utils from 'utils/utils';
 import LoadingScreen from 'components/loading_screen';
+
+import NextIcon from 'components/widgets/icons/fa_next_icon';
+import PreviousIcon from 'components/widgets/icons/fa_previous_icon';
 import SearchIcon from 'components/widgets/icons/fa_search_icon';
+
+import {PAGE_SIZE} from 'components/admin_console/team_channel_settings/abstract_list';
 
 export default class BackstageList extends React.PureComponent {
     static propTypes = {
@@ -21,6 +27,9 @@ export default class BackstageList extends React.PureComponent {
         helpText: PropTypes.node,
         loading: PropTypes.bool.isRequired,
         searchPlaceholder: PropTypes.string,
+        nextPage: PropTypes.func,
+        previousPage: PropTypes.func,
+        page: PropTypes.number,
     }
 
     static defaultProps = {
@@ -32,6 +41,9 @@ export default class BackstageList extends React.PureComponent {
 
         this.state = {
             filter: '',
+            initPage: props.page,
+            startCount: this.props.initPage ? (this.props.initPage * PAGE_SIZE) + 1 : 1,
+            endCount: this.props.initPage ? (this.props.initPage + 1) * PAGE_SIZE : PAGE_SIZE,
         };
     }
 
@@ -41,9 +53,78 @@ export default class BackstageList extends React.PureComponent {
         });
     }
 
+    nextPage = () => {
+        if (!this.props.loading) {
+            this.props.nextPage();
+        }
+    }
+
+    previousPage = () => {
+        if (!this.props.loading) {
+            this.props.previousPage();
+        }
+    }
+
+    renderFooter = (total) => {
+        const page = this.props.page;
+        if (typeof page == 'undefined') {
+            return null;
+        }
+        let footer = null;
+        if (total) {
+            const start = this.state.startCount;
+            let end = this.state.endCount;
+            end = end > total ? total : end; 
+            const firstPage = this.state.startCount <= 1;
+            const lastPage = end >= total;
+
+            let prevPageFn = this.previousPage;
+            if (firstPage) {
+                prevPageFn = () => {};
+            }
+
+            let nextPageFn = this.nextPage;
+            if (lastPage) {
+                nextPageFn = () => {};
+            }
+            
+            footer = (  
+                <div className='backstage-list__paging'>
+                    <FormattedMessage
+                        id='backstage-list.paginatorCount'
+                        defaultMessage='{start, number} - {end, number} of {total, number}'
+                        values={{
+                            start,
+                            end,
+                            total,
+                        }}
+                    />
+
+                    <button
+                        type='button'
+                        className={'btn btn-link prev ' + (firstPage ? 'disabled' : '')}
+                        onClick={prevPageFn}
+                        disabled={firstPage}
+                    >
+                        <PreviousIcon/>
+                    </button>
+                    <button
+                        type='button'
+                        className={'btn btn-link next ' + (lastPage ? 'disabled' : '')}
+                        onClick={nextPageFn}
+                        disabled={lastPage}
+                    >
+                        <NextIcon/>
+                    </button>
+                </div>
+            );
+        }
+        return footer;
+    }
+    
     render() {
         const filter = this.state.filter.toLowerCase();
-
+        let total = 0;
         let children;
         if (this.props.loading) {
             children = <LoadingScreen/>;
@@ -56,6 +137,9 @@ export default class BackstageList extends React.PureComponent {
             children = React.Children.map(children, (child) => {
                 return React.cloneElement(child, {filter});
             });
+            total = children.length;
+            const endCount = this.state.endCount > total ? total : this.state.endCount; 
+            children = children.slice(this.state.startCount - 1, endCount);
             if (children.length === 0 || !hasChildren) {
                 if (!filter) {
                     if (this.props.emptyText) {
@@ -126,6 +210,9 @@ export default class BackstageList extends React.PureComponent {
                 </span>
                 <div className='backstage-list'>
                     {children}
+                </div>
+                <div className='backstage-list__footer'>
+                    {this.renderFooter(total)}
                 </div>
             </div>
         );

--- a/components/backstage/components/backstage_list.jsx
+++ b/components/backstage/components/backstage_list.jsx
@@ -41,9 +41,6 @@ export default class BackstageList extends React.PureComponent {
 
         this.state = {
             filter: '',
-            initPage: props.page,
-            startCount: this.props.initPage ? (this.props.initPage * PAGE_SIZE) + 1 : 1,
-            endCount: this.props.initPage ? (this.props.initPage + 1) * PAGE_SIZE : PAGE_SIZE,
         };
     }
 
@@ -51,6 +48,15 @@ export default class BackstageList extends React.PureComponent {
         this.setState({
             filter: e.target.value,
         });
+    }
+
+    getPaginationProps(total) {
+        const page = this.props.page;
+        const startCount = (page * PAGE_SIZE) + 1;
+        let endCount = 0;
+        endCount = (page + 1) * PAGE_SIZE;
+        endCount = endCount > total ? total : endCount;
+        return {startCount, endCount};
     }
 
     nextPage = () => {
@@ -72,11 +78,9 @@ export default class BackstageList extends React.PureComponent {
         }
         let footer = null;
         if (total) {
-            const start = this.state.startCount;
-            let end = this.state.endCount;
-            end = end > total ? total : end; 
-            const firstPage = this.state.startCount <= 1;
-            const lastPage = end >= total;
+            const {startCount, endCount} = this.getPaginationProps(total)
+            const firstPage = startCount <= 1;
+            const lastPage = endCount >= total;
 
             let prevPageFn = this.previousPage;
             if (firstPage) {
@@ -92,10 +96,10 @@ export default class BackstageList extends React.PureComponent {
                 <div className='backstage-list__paging'>
                     <FormattedMessage
                         id='backstage-list.paginatorCount'
-                        defaultMessage='{start, number} - {end, number} of {total, number}'
+                        defaultMessage='{startCount, number} - {endCount, number} of {total, number}'
                         values={{
-                            start,
-                            end,
+                            startCount,
+                            endCount,
                             total,
                         }}
                     />
@@ -138,8 +142,8 @@ export default class BackstageList extends React.PureComponent {
                 return React.cloneElement(child, {filter});
             });
             total = children.length;
-            const endCount = this.state.endCount > total ? total : this.state.endCount; 
-            children = children.slice(this.state.startCount - 1, endCount);
+            const {startCount, endCount} = this.getPaginationProps(total); 
+            children = children.slice(startCount - 1, endCount);
             if (children.length === 0 || !hasChildren) {
                 if (!filter) {
                     if (this.props.emptyText) {

--- a/components/integrations/abstract_incoming_webhook.jsx
+++ b/components/integrations/abstract_incoming_webhook.jsx
@@ -73,6 +73,7 @@ export default class AbstractIncomingWebhook extends React.PureComponent {
             description: hook.description || '',
             channelId: hook.channel_id || '',
             channelLocked: hook.channel_locked || false,
+            enabled: hook.enabled ?? true,
             username: hook.username || '',
             iconURL: hook.icon_url || '',
             saving: false,
@@ -111,12 +112,14 @@ export default class AbstractIncomingWebhook extends React.PureComponent {
         const hook = {
             channel_id: this.state.channelId,
             channel_locked: this.state.channelLocked,
+            enabled: this.state.enabled,
             display_name: this.state.displayName,
             description: this.state.description,
             username: this.state.username,
             icon_url: this.state.iconURL,
         };
 
+        console.log(hook);
         this.props.action(hook).then(() => this.setState({saving: false}));
     }
 
@@ -141,6 +144,12 @@ export default class AbstractIncomingWebhook extends React.PureComponent {
     updateChannelLocked = (e) => {
         this.setState({
             channelLocked: e.target.checked,
+        });
+    }
+
+    updateEnabled = (e) => {
+        this.setState({
+            enabled: e.target.checked,
         });
     }
 
@@ -280,6 +289,31 @@ export default class AbstractIncomingWebhook extends React.PureComponent {
                                     <FormattedMessage
                                         id='add_incoming_webhook.channelLocked.help'
                                         defaultMessage='If set, the incoming webhook can post only to the selected channel.'
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                        <div className='form-group'>
+                            <label
+                                className='control-label col-sm-4'
+                                htmlFor='enabled'
+                            >
+                                <FormattedMessage
+                                    id='add_incoming_webhook.enabled'
+                                    defaultMessage='Enable webhook'
+                                />
+                            </label>
+                            <div className='col-md-5 col-sm-8 checkbox'>
+                                <input
+                                    id='enabled'
+                                    type='checkbox'
+                                    checked={this.state.enabled}
+                                    onChange={this.updateEnabled}
+                                />
+                                <div className='form__help'>
+                                    <FormattedMessage
+                                        id='add_incoming_webhook.enabled.help'
+                                        defaultMessage='If set, the incoming webhook will be enabled!'
                                     />
                                 </div>
                             </div>

--- a/components/integrations/abstract_incoming_webhook.jsx
+++ b/components/integrations/abstract_incoming_webhook.jsx
@@ -119,7 +119,6 @@ export default class AbstractIncomingWebhook extends React.PureComponent {
             icon_url: this.state.iconURL,
         };
 
-        console.log(hook);
         this.props.action(hook).then(() => this.setState({saving: false}));
     }
 
@@ -313,7 +312,7 @@ export default class AbstractIncomingWebhook extends React.PureComponent {
                                 <div className='form__help'>
                                     <FormattedMessage
                                         id='add_incoming_webhook.enabled.help'
-                                        defaultMessage='If set, the incoming webhook will be enabled!'
+                                        defaultMessage='If set, the incoming webhook will be enabled.'
                                     />
                                 </div>
                             </div>

--- a/components/integrations/abstract_outgoing_webhook.jsx
+++ b/components/integrations/abstract_outgoing_webhook.jsx
@@ -101,6 +101,7 @@ export default class AbstractOutgoingWebhook extends React.PureComponent {
             clientError: null,
             username: hook.username || '',
             iconURL: hook.icon_url || '',
+            enabled: hook.enabled ?? true,
         };
     }
 
@@ -175,6 +176,7 @@ export default class AbstractOutgoingWebhook extends React.PureComponent {
             description: this.state.description,
             username: this.state.username,
             icon_url: this.state.iconURL,
+            enabled: this.state.enabled,
         };
 
         this.props.action(hook).then(() => this.setState({saving: false}));
@@ -231,6 +233,12 @@ export default class AbstractOutgoingWebhook extends React.PureComponent {
     updateIconURL = (e) => {
         this.setState({
             iconURL: e.target.value,
+        });
+    }
+
+    updateEnabled = (e) => {
+        this.setState({
+            enabled: e.target.checked,
         });
     }
 
@@ -486,6 +494,31 @@ export default class AbstractOutgoingWebhook extends React.PureComponent {
                                                 </a>
                                             ),
                                         }}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                        <div className='form-group'>
+                            <label
+                                className='control-label col-sm-4'
+                                htmlFor='enabled'
+                            >
+                                <FormattedMessage
+                                    id='add_outgoing_webhook.enabled'
+                                    defaultMessage='Enable webhook'
+                                />
+                            </label>
+                            <div className='col-md-5 col-sm-8 checkbox'>
+                                <input
+                                    id='enabled'
+                                    type='checkbox'
+                                    checked={this.state.enabled}
+                                    onChange={this.updateEnabled}
+                                />
+                                <div className='form__help'>
+                                    <FormattedMessage
+                                        id='add_outgoing_webhook.enabled.help'
+                                        defaultMessage='If set, the outgoing webhook will be enabled.'
                                     />
                                 </div>
                             </div>

--- a/components/integrations/installed_incoming_webhook.jsx
+++ b/components/integrations/installed_incoming_webhook.jsx
@@ -9,6 +9,7 @@ import {Link} from 'react-router-dom';
 import {getSiteURL} from 'utils/url';
 
 import CopyText from 'components/copy_text';
+import Toggle from 'components/toggle';
 
 import DeleteIntegrationLink from './delete_integration_link';
 
@@ -45,6 +46,11 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
         onDelete: PropTypes.func.isRequired,
 
         /**
+        * Function to enable or disable webhook when toggle button is pressed
+        */
+         onToggle: PropTypes.func.isRequired,
+
+        /**
         * String used for filtering webhook item
         */
         filter: PropTypes.string,
@@ -74,6 +80,15 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
         this.props.onDelete(this.props.incomingWebhook);
     }
 
+    handleToggle = () => {
+        var incomingWebhook = this.props.incomingWebhook
+        const toggledWebhook = {
+            ...incomingWebhook,
+            enabled: !incomingWebhook.enabled,
+        };
+        this.props.onToggle(toggledWebhook);
+    }
+
     render() {
         const incomingWebhook = this.props.incomingWebhook;
         const channel = this.props.channel;
@@ -93,6 +108,23 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
                 <FormattedMessage
                     id='installed_incoming_webhooks.unknown_channel'
                     defaultMessage='A Private Webhook'
+                />
+            );
+        }
+
+        let displayEnabled;
+        if(incomingWebhook.enabled) {
+            displayEnabled = (
+                <FormattedMessage
+                    id='installed_incoming_webhooks.enabled_webhook'
+                    defaultMessage=' - Enabled'
+                />
+            );
+        } else {
+            displayEnabled = (
+                <FormattedMessage
+                    id='installed_incoming_webhooks.disabled_webhook'
+                    defaultMessage=' - Disabled'
                 />
             );
         }
@@ -128,6 +160,12 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
                         }
                         onDelete={this.handleDelete}
                     />
+                    {' - '}
+                    <Toggle
+                        disabled={false}
+                        onToggle={this.handleToggle}
+                        toggled={this.props.incomingWebhook.enabled}
+                    />
                 </div>
             );
         }
@@ -140,6 +178,7 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
                     <div className='item-details__row d-flex flex-column flex-md-row justify-content-between'>
                         <strong className='item-details__name'>
                             {displayName}
+                            {displayEnabled}
                         </strong>
                         {actions}
                     </div>

--- a/components/integrations/installed_incoming_webhooks/index.ts
+++ b/components/integrations/installed_incoming_webhooks/index.ts
@@ -16,7 +16,7 @@ import {Permissions} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {ActionResult, GenericAction} from 'mattermost-redux/types/actions';
 
-import {loadIncomingHooksAndProfilesForTeam} from 'actions/integration_actions.jsx';
+import {loadAllIncomingHooksAndProfilesForTeam} from 'actions/integration_actions.jsx';
 
 import InstalledIncomingWebhooks from './installed_incoming_webhooks';
 
@@ -24,7 +24,7 @@ import {IncomingWebhook} from '@mattermost/types/integrations';
 type Actions = {
     removeIncomingHook: (hookId: string) => Promise<ActionResult>;
     updateIncomingHook: (hook: IncomingWebhook) => Promise<ActionResult>
-    loadIncomingHooksAndProfilesForTeam: (teamId: string, startPageNumber: number, pageSize: string) => Promise<ActionResult>;
+    loadAllIncomingHooksAndProfilesForTeam: (teamId: string) => Promise<ActionResult>;
 }
 
 function mapStateToProps(state: GlobalState) {
@@ -49,7 +49,7 @@ function mapStateToProps(state: GlobalState) {
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<any>, Actions>({
-            loadIncomingHooksAndProfilesForTeam,
+            loadAllIncomingHooksAndProfilesForTeam,
             removeIncomingHook,
             updateIncomingHook,
         }, dispatch),

--- a/components/integrations/installed_incoming_webhooks/index.ts
+++ b/components/integrations/installed_incoming_webhooks/index.ts
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {ActionCreatorsMapObject, bindActionCreators, Dispatch} from 'redux';
 
-import {removeIncomingHook} from 'mattermost-redux/actions/integrations';
+import {removeIncomingHook, updateIncomingHook} from 'mattermost-redux/actions/integrations';
 
 import {getAllChannels} from 'mattermost-redux/selectors/entities/channels';
 import {getIncomingHooks} from 'mattermost-redux/selectors/entities/integrations';
@@ -20,8 +20,10 @@ import {loadIncomingHooksAndProfilesForTeam} from 'actions/integration_actions.j
 
 import InstalledIncomingWebhooks from './installed_incoming_webhooks';
 
+import {IncomingWebhook} from '@mattermost/types/integrations';
 type Actions = {
     removeIncomingHook: (hookId: string) => Promise<ActionResult>;
+    updateIncomingHook: (hook: IncomingWebhook) => Promise<ActionResult>
     loadIncomingHooksAndProfilesForTeam: (teamId: string, startPageNumber: number, pageSize: string) => Promise<ActionResult>;
 }
 
@@ -49,6 +51,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
         actions: bindActionCreators<ActionCreatorsMapObject<any>, Actions>({
             loadIncomingHooksAndProfilesForTeam,
             removeIncomingHook,
+            updateIncomingHook,
         }, dispatch),
     };
 }

--- a/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.tsx
+++ b/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.tsx
@@ -28,6 +28,7 @@ type Props = {
     enableIncomingWebhooks: boolean;
     actions: {
         removeIncomingHook: (hookId: string) => Promise<ActionResult>;
+        updateIncomingHook: (hook : IncomingWebhook) => Promise<ActionResult>;
         loadIncomingHooksAndProfilesForTeam: (teamId: string, startPageNumber: number,
             pageSize: string) => Promise<ActionResult>;
     };
@@ -62,6 +63,10 @@ export default class InstalledIncomingWebhooks extends React.PureComponent<Props
         this.props.actions.removeIncomingHook(incomingWebhook.id);
     }
 
+    toggleIncomingWebhook = (incomingWebhook: IncomingWebhook) => {
+        this.props.actions.updateIncomingHook(incomingWebhook);
+    }
+
     incomingWebhookCompare = (a: IncomingWebhook, b: IncomingWebhook) => {
         let displayNameA = a.display_name;
         if (!displayNameA) {
@@ -89,6 +94,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent<Props
                     key={incomingWebhook.id}
                     incomingWebhook={incomingWebhook}
                     onDelete={this.deleteIncomingWebhook}
+                    onToggle={this.toggleIncomingWebhook}
                     creator={this.props.users[incomingWebhook.user_id] || {}}
                     canChange={canChange}
                     team={this.props.team}

--- a/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.tsx
+++ b/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.tsx
@@ -15,7 +15,6 @@ import BackstageList from 'components/backstage/components/backstage_list.jsx';
 import InstalledIncomingWebhook, {matchesFilter} from 'components/integrations/installed_incoming_webhook.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
-import Constants from 'utils/constants';
 import * as Utils from 'utils/utils';
 
 type Props = {
@@ -29,13 +28,13 @@ type Props = {
     actions: {
         removeIncomingHook: (hookId: string) => Promise<ActionResult>;
         updateIncomingHook: (hook : IncomingWebhook) => Promise<ActionResult>;
-        loadIncomingHooksAndProfilesForTeam: (teamId: string, startPageNumber: number,
-            pageSize: string) => Promise<ActionResult>;
+        loadAllIncomingHooksAndProfilesForTeam: (teamId: string) => Promise<ActionResult>;
     };
 }
 
 type State = {
     loading: boolean;
+    page: number;
 }
 
 export default class InstalledIncomingWebhooks extends React.PureComponent<Props, State> {
@@ -44,15 +43,14 @@ export default class InstalledIncomingWebhooks extends React.PureComponent<Props
 
         this.state = {
             loading: true,
+            page: 0,
         };
     }
 
     componentDidMount() {
         if (this.props.enableIncomingWebhooks) {
-            this.props.actions.loadIncomingHooksAndProfilesForTeam(
+            this.props.actions.loadAllIncomingHooksAndProfilesForTeam(
                 this.props.team.id,
-                Constants.Integrations.START_PAGE_NUM,
-                Constants.Integrations.PAGE_SIZE,
             ).then(
                 () => this.setState({loading: false}),
             );
@@ -83,6 +81,14 @@ export default class InstalledIncomingWebhooks extends React.PureComponent<Props
         return displayNameA.localeCompare(displayNameB);
     }
 
+    nextPage = () => {
+        this.setState({page: this.state.page + 1})
+    }
+
+    previousPage = () => {
+        this.setState({page: this.state.page - 1});
+    }
+
     incomingWebhooks = (filter: string) => this.props.incomingWebhooks.
         sort(this.incomingWebhookCompare).
         filter((incomingWebhook: IncomingWebhook) => matchesFilter(incomingWebhook, this.props.channels[incomingWebhook.channel_id], filter)).
@@ -105,73 +111,76 @@ export default class InstalledIncomingWebhooks extends React.PureComponent<Props
 
     render() {
         return (
-            <BackstageList
-                header={
-                    <FormattedMessage
-                        id='installed_incoming_webhooks.header'
-                        defaultMessage='Installed Incoming Webhooks'
-                    />
-                }
-                addText={
-                    <FormattedMessage
-                        id='installed_incoming_webhooks.add'
-                        defaultMessage='Add Incoming Webhook'
-                    />
-                }
-                addLink={'/' + this.props.team.name + '/integrations/incoming_webhooks/add'}
-                addButtonId='addIncomingWebhook'
-                emptyText={
-                    <FormattedMessage
-                        id='installed_incoming_webhooks.empty'
-                        defaultMessage='No incoming webhooks found'
-                    />
-                }
-                emptyTextSearch={
-                    <FormattedMarkdownMessage
-                        id='installed_incoming_webhooks.emptySearch'
-                        defaultMessage='No incoming webhooks match {searchTerm}'
-                    />
-                }
-                helpText={
-                    <FormattedMessage
-                        id='installed_incoming_webhooks.help'
-                        defaultMessage='Use incoming webhooks to connect external tools to Mattermost. {buildYourOwn} or visit the {appDirectory} to find self-hosted, third-party apps and integrations.'
-                        values={{
-                            buildYourOwn: (
-                                <a
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    href='https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/'
-                                >
-                                    <FormattedMessage
-                                        id='installed_incoming_webhooks.help.buildYourOwn'
-                                        defaultMessage='Build Your Own'
-                                    />
-                                </a>
-                            ),
-                            appDirectory: (
-                                <a
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    href='https://mattermost.com/marketplace'
-                                >
-                                    <FormattedMessage
-                                        id='installed_incoming_webhooks.help.appDirectory'
-                                        defaultMessage='App Directory'
-                                    />
-                                </a>
-                            ),
-                        }}
-                    />
-                }
-                searchPlaceholder={Utils.localizeMessage('installed_incoming_webhooks.search', 'Search Incoming Webhooks')}
-                loading={this.state.loading}
-            >
-                {(filter: string) => {
-                    const children = this.incomingWebhooks(filter);
-                    return [children, children.length > 0];
-                }}
-            </BackstageList>
+                <BackstageList
+                    header={
+                        <FormattedMessage
+                            id='installed_incoming_webhooks.header'
+                            defaultMessage='Installed Incoming Webhooks'
+                        />
+                    }
+                    addText={
+                        <FormattedMessage
+                            id='installed_incoming_webhooks.add'
+                            defaultMessage='Add Incoming Webhook'
+                        />
+                    }
+                    addLink={'/' + this.props.team.name + '/integrations/incoming_webhooks/add'}
+                    addButtonId='addIncomingWebhook'
+                    emptyText={
+                        <FormattedMessage
+                            id='installed_incoming_webhooks.empty'
+                            defaultMessage='No incoming webhooks found'
+                        />
+                    }
+                    emptyTextSearch={
+                        <FormattedMarkdownMessage
+                            id='installed_incoming_webhooks.emptySearch'
+                            defaultMessage='No incoming webhooks match {searchTerm}'
+                        />
+                    }
+                    helpText={
+                        <FormattedMessage
+                            id='installed_incoming_webhooks.help'
+                            defaultMessage='Use incoming webhooks to connect external tools to Mattermost. {buildYourOwn} or visit the {appDirectory} to find self-hosted, third-party apps and integrations.'
+                            values={{
+                                buildYourOwn: (
+                                    <a
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                        href='https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/'
+                                    >
+                                        <FormattedMessage
+                                            id='installed_incoming_webhooks.help.buildYourOwn'
+                                            defaultMessage='Build Your Own'
+                                        />
+                                    </a>
+                                ),
+                                appDirectory: (
+                                    <a
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                        href='https://mattermost.com/marketplace'
+                                    >
+                                        <FormattedMessage
+                                            id='installed_incoming_webhooks.help.appDirectory'
+                                            defaultMessage='App Directory'
+                                        />
+                                    </a>
+                                ),
+                            }}
+                        />
+                    }
+                    searchPlaceholder={Utils.localizeMessage('installed_incoming_webhooks.search', 'Search Incoming Webhooks')}
+                    loading={this.state.loading}
+                    nextPage={this.nextPage}
+                    previousPage={this.previousPage}
+                    page={this.state.page}
+                >
+                    {(filter: string) => {
+                        const children = this.incomingWebhooks(filter);
+                        return [children, children.length > 0];
+                    }}
+                </BackstageList>
         );
     }
 }

--- a/components/integrations/installed_outgoing_webhook.jsx
+++ b/components/integrations/installed_outgoing_webhook.jsx
@@ -7,6 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import CopyText from 'components/copy_text';
+import Toggle from 'components/toggle';
 
 import DeleteIntegrationLink from './delete_integration_link';
 
@@ -99,6 +100,15 @@ export default class InstalledOutgoingWebhook extends React.PureComponent {
         this.props.onDelete(this.props.outgoingWebhook);
     }
 
+    handleToggle = () => {
+        var outgoingWebhook = this.props.outgoingWebhook
+        const toggledWebhook = {
+            ...outgoingWebhook,
+            enabled: !outgoingWebhook.enabled,
+        };
+        this.props.onToggle(toggledWebhook);
+    }
+
     makeDisplayName(outgoingWebhook, channel) {
         if (outgoingWebhook.display_name) {
             return outgoingWebhook.display_name;
@@ -125,6 +135,23 @@ export default class InstalledOutgoingWebhook extends React.PureComponent {
         }
 
         const displayName = this.makeDisplayName(outgoingWebhook, channel);
+
+        let displayEnabled;
+        if(outgoingWebhook.enabled) {
+            displayEnabled = (
+                <FormattedMessage
+                    id='installed_outgoing_webhooks.enabled_webhook'
+                    defaultMessage=' - Enabled'
+                />
+            );
+        } else {
+            displayEnabled = (
+                <FormattedMessage
+                    id='installed_outgoing_webhooks.disabled_webhook'
+                    defaultMessage=' - Disabled'
+                />
+            );
+        }
 
         let description = null;
         if (outgoingWebhook.description) {
@@ -215,6 +242,12 @@ export default class InstalledOutgoingWebhook extends React.PureComponent {
                         }
                         onDelete={this.handleDelete}
                     />
+                    {' - '}
+                    <Toggle
+                        disabled={false}
+                        onToggle={this.handleToggle}
+                        toggled={this.props.outgoingWebhook.enabled}
+                    />
                 </div>
             );
         }
@@ -225,6 +258,7 @@ export default class InstalledOutgoingWebhook extends React.PureComponent {
                     <div className='item-details__row d-flex flex-column flex-md-row justify-content-between'>
                         <strong className='item-details__name'>
                             {displayName}
+                            {displayEnabled}
                         </strong>
                         {actions}
                     </div>

--- a/components/integrations/installed_outgoing_webhooks/index.ts
+++ b/components/integrations/installed_outgoing_webhooks/index.ts
@@ -43,6 +43,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators<ActionCreatorsMapObject<any>, Props['actions']>({
             loadOutgoingHooksAndProfilesForTeam,
             removeOutgoingHook: Actions.removeOutgoingHook,
+            updateOutgoingHook: Actions.updateOutgoingHook,
             regenOutgoingHookToken: Actions.regenOutgoingHookToken,
         }, dispatch),
     };

--- a/components/integrations/installed_outgoing_webhooks/index.ts
+++ b/components/integrations/installed_outgoing_webhooks/index.ts
@@ -12,7 +12,7 @@ import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
-import {loadOutgoingHooksAndProfilesForTeam} from 'actions/integration_actions';
+import {loadAllOutgoingHooksAndProfilesForTeam} from 'actions/integration_actions';
 
 import {GlobalState} from 'types/store';
 
@@ -41,7 +41,7 @@ function mapStateToProps(state: GlobalState) {
 function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<any>, Props['actions']>({
-            loadOutgoingHooksAndProfilesForTeam,
+            loadAllOutgoingHooksAndProfilesForTeam,
             removeOutgoingHook: Actions.removeOutgoingHook,
             updateOutgoingHook: Actions.updateOutgoingHook,
             regenOutgoingHookToken: Actions.regenOutgoingHookToken,

--- a/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
+++ b/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
@@ -62,6 +62,11 @@ export type Props = {
         removeOutgoingHook: (hookId: string) => Promise<void>;
 
         /**
+         * The function to call for updating outgoingWebhook
+         */
+        updateOutgoingHook: (hook: OutgoingWebhook) => Promise<void>;
+
+        /**
         * The function to call for outgoingWebhook List and for the status of api
         */
         loadOutgoingHooksAndProfilesForTeam: (teamId: string, page: number, perPage: number) => Promise<void>;
@@ -111,6 +116,10 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
         this.props.actions.removeOutgoingHook(outgoingWebhook.id);
     }
 
+    toggleOutgoingHook = (outgoingWebhook: OutgoingWebhook) => {
+        this.props.actions.updateOutgoingHook(outgoingWebhook);
+    }
+
     outgoingWebhookCompare = (a: OutgoingWebhook, b: OutgoingWebhook) => {
         let displayNameA = a.display_name;
         if (!displayNameA) {
@@ -146,6 +155,7 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
                     outgoingWebhook={outgoingWebhook}
                     onRegenToken={this.regenOutgoingWebhookToken}
                     onDelete={this.removeOutgoingHook}
+                    onToggle={this.toggleOutgoingHook}
                     creator={this.props.users[outgoingWebhook.creator_id] || {}}
                     canChange={canChange}
                     team={this.props.team}

--- a/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
+++ b/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
@@ -69,7 +69,7 @@ export type Props = {
         /**
         * The function to call for outgoingWebhook List and for the status of api
         */
-        loadOutgoingHooksAndProfilesForTeam: (teamId: string, page: number, perPage: number) => Promise<void>;
+        loadAllOutgoingHooksAndProfilesForTeam: (teamId: string) => Promise<void>;
 
         /**
         * The function to call for regeneration of webhook token
@@ -85,6 +85,7 @@ export type Props = {
 
 type State = {
     loading: boolean;
+    page: number;
 };
 
 export default class InstalledOutgoingWebhooks extends React.PureComponent<Props, State> {
@@ -93,15 +94,14 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
 
         this.state = {
             loading: true,
+            page: 0,
         };
     }
 
     componentDidMount() {
         if (this.props.enableOutgoingWebhooks) {
-            this.props.actions.loadOutgoingHooksAndProfilesForTeam(
+            this.props.actions.loadAllOutgoingHooksAndProfilesForTeam(
                 this.props.teamId,
-                Constants.Integrations.START_PAGE_NUM,
-                parseInt(Constants.Integrations.PAGE_SIZE, 10),
             ).then(
                 () => this.setState({loading: false}),
             );
@@ -143,6 +143,15 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
         return displayNameA.localeCompare(displayNameB);
     }
 
+    nextPage = () => {
+        this.setState({page: this.state.page + 1})
+    }
+
+    previousPage = () => {
+        this.setState({page: this.state.page - 1});
+    }
+
+
     outgoingWebhooks = (filter: string) => this.props.outgoingWebhooks.
         sort(this.outgoingWebhookCompare).
         filter((outgoingWebhook) => matchesFilter(outgoingWebhook, this.props.channels[outgoingWebhook.channel_id], filter)).
@@ -166,73 +175,76 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
 
     render() {
         return (
-            <BackstageList
-                header={
-                    <FormattedMessage
-                        id='installed_outgoing_webhooks.header'
-                        defaultMessage='Installed Outgoing Webhooks'
-                    />
-                }
-                addText={
-                    <FormattedMessage
-                        id='installed_outgoing_webhooks.add'
-                        defaultMessage='Add Outgoing Webhook'
-                    />
-                }
-                addLink={'/' + this.props.team.name + '/integrations/outgoing_webhooks/add'}
-                addButtonId='addOutgoingWebhook'
-                emptyText={
-                    <FormattedMessage
-                        id='installed_outgoing_webhooks.empty'
-                        defaultMessage='No outgoing webhooks found'
-                    />
-                }
-                emptyTextSearch={
-                    <FormattedMarkdownMessage
-                        id='installed_outgoing_webhooks.emptySearch'
-                        defaultMessage='No outgoing webhooks match {searchTerm}'
-                    />
-                }
-                helpText={
-                    <FormattedMessage
-                        id='installed_outgoing_webhooks.help'
-                        defaultMessage='Use outgoing webhooks to connect external tools to Mattermost. {buildYourOwn} or visit the {appDirectory} to find self-hosted, third-party apps and integrations.'
-                        values={{
-                            buildYourOwn: (
-                                <a
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    href='https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-outgoing/'
-                                >
-                                    <FormattedMessage
-                                        id='installed_outgoing_webhooks.help.buildYourOwn'
-                                        defaultMessage='Build your own'
-                                    />
-                                </a>
-                            ),
-                            appDirectory: (
-                                <a
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    href='https://mattermost.com/marketplace'
-                                >
-                                    <FormattedMessage
-                                        id='installed_outgoing_webhooks.help.appDirectory'
-                                        defaultMessage='App Directory'
-                                    />
-                                </a>
-                            ),
+                <BackstageList
+                    header={
+                        <FormattedMessage
+                            id='installed_outgoing_webhooks.header'
+                            defaultMessage='Installed Outgoing Webhooks'
+                        />
+                    }
+                    addText={
+                        <FormattedMessage
+                            id='installed_outgoing_webhooks.add'
+                            defaultMessage='Add Outgoing Webhook'
+                        />
+                    }
+                    addLink={'/' + this.props.team.name + '/integrations/outgoing_webhooks/add'}
+                    addButtonId='addOutgoingWebhook'
+                    emptyText={
+                        <FormattedMessage
+                            id='installed_outgoing_webhooks.empty'
+                            defaultMessage='No outgoing webhooks found'
+                        />
+                    }
+                    emptyTextSearch={
+                        <FormattedMarkdownMessage
+                            id='installed_outgoing_webhooks.emptySearch'
+                            defaultMessage='No outgoing webhooks match {searchTerm}'
+                        />
+                    }
+                    helpText={
+                        <FormattedMessage
+                            id='installed_outgoing_webhooks.help'
+                            defaultMessage='Use outgoing webhooks to connect external tools to Mattermost. {buildYourOwn} or visit the {appDirectory} to find self-hosted, third-party apps and integrations.'
+                            values={{
+                                buildYourOwn: (
+                                    <a
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                        href='https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-outgoing/'
+                                    >
+                                        <FormattedMessage
+                                            id='installed_outgoing_webhooks.help.buildYourOwn'
+                                            defaultMessage='Build your own'
+                                        />
+                                    </a>
+                                ),
+                                appDirectory: (
+                                    <a
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                        href='https://mattermost.com/marketplace'
+                                    >
+                                        <FormattedMessage
+                                            id='installed_outgoing_webhooks.help.appDirectory'
+                                            defaultMessage='App Directory'
+                                        />
+                                    </a>
+                                ),
+                            }}
+                        />
+                    }
+                    searchPlaceholder={localizeMessage('installed_outgoing_webhooks.search', 'Search Outgoing Webhooks')}
+                    loading={this.state.loading}
+                    nextPage={this.nextPage}
+                    previousPage={this.previousPage}
+                    page={this.state.page}
+                    >
+                        {(filter: string) => {
+                            const children = this.outgoingWebhooks(filter);
+                            return [children, children.length > 0];
                         }}
-                    />
-                }
-                searchPlaceholder={localizeMessage('installed_outgoing_webhooks.search', 'Search Outgoing Webhooks')}
-                loading={this.state.loading}
-            >
-                {(filter: string) => {
-                    const children = this.outgoingWebhooks(filter);
-                    return [children, children.length > 0];
-                }}
-            </BackstageList>
+                </BackstageList>
         );
     }
 }

--- a/packages/types/src/integrations.ts
+++ b/packages/types/src/integrations.ts
@@ -17,6 +17,7 @@ export type IncomingWebhook = {
     username: string;
     icon_url: string;
     channel_locked: boolean;
+    enabled: boolean;
 };
 
 export type OutgoingWebhook = {
@@ -36,6 +37,7 @@ export type OutgoingWebhook = {
     content_type: string;
     username: string;
     icon_url: string;
+    enabled: boolean;
 };
 
 export type Command = {

--- a/utils/test_helper.ts
+++ b/utils/test_helper.ts
@@ -259,6 +259,7 @@ export class TestHelper {
             username: '',
             icon_url: '',
             channel_locked: false,
+            enabled: true,
         };
         return Object.assign({}, defaultIncomingWebhook, override);
     }


### PR DESCRIPTION
#### Summary
Adds pagination functionality so that all incoming and outgoing webhooks can be viewed in the integrations page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40546

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (https://github.com/mattermost/mattermost-server/pull/21183)
- Has webapp changes (https://github.com/mattermost/mattermost-webapp/pull/11261)

#### Screenshots
![image](https://user-images.githubusercontent.com/26048106/200957329-8f598842-0c9d-4f6c-8095-4bdfbcf010e6.png)
![image](https://user-images.githubusercontent.com/26048106/200957365-dd31fef9-d71a-4128-a91e-4697cc2d5a1e.png)
Incoming and Outgoing Webhooks view - in contrast to the original, there is a new page navigation view with next and previous page buttons at the bottom. Each page is 10 entries by default, and clicking the buttons (when enabled) navigates to the next/previous page, in contrast to listing up to 200 hooks as done previously.

#### Release Note
* Added paginated viewing to incoming and outgoing webhooks